### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -7,6 +7,7 @@ import sys
 import shutil
 import hashlib
 from six.moves.urllib.request import urlopen
+from urllib.parse import urlparse
 from six.moves.urllib.error import URLError, HTTPError
 
 import requests
@@ -112,7 +113,8 @@ def get_file(fname, origin, untar=False,
     '''
 
     if download:
-        if 'modac.cancer.gov' in origin:
+        from urllib.parse import urlparse
+        if urlparse(origin).hostname == 'modac.cancer.gov':
             get_file_from_modac(fpath, origin)
         else:
             print('Downloading data from', origin)


### PR DESCRIPTION
Potential fix for [https://github.com/CBIIT/NCI-DOE-Collab-Pilot1-Learning-Curve/security/code-scanning/1](https://github.com/CBIIT/NCI-DOE-Collab-Pilot1-Learning-Curve/security/code-scanning/1)

To fix the issue, the code should use the `urlparse` function from Python's `urllib.parse` module to extract the hostname from the `origin` URL. The hostname can then be checked to ensure it matches `'modac.cancer.gov'`. This approach ensures that the substring `'modac.cancer.gov'` is not accidentally matched in unintended parts of the URL, such as the path or query parameters.

**Steps to implement the fix:**
1. Import `urlparse` from `urllib.parse` if not already imported.
2. Replace the substring check `'modac.cancer.gov' in origin` with a check on the parsed hostname using `urlparse(origin).hostname == 'modac.cancer.gov'`.
3. Ensure the logic remains functionally equivalent, i.e., the `get_file_from_modac` function is called only when the hostname matches `'modac.cancer.gov'`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
